### PR TITLE
bugfix for program failure when replace gpu

### DIFF
--- a/OpenCLforNet/Extension.cs
+++ b/OpenCLforNet/Extension.cs
@@ -9,9 +9,12 @@ namespace OpenCLforNet
 {
     static class Extension
     {
+        public static bool HasError(this cl_status_code code)
+            => code != cl_status_code.CL_SUCCESS;
+
         public static void CheckError(this cl_status_code code)
         {
-            if (code != cl_status_code.CL_SUCCESS)
+            if (HasError(code))
             {
                 throw new Exception(Enum.GetName(typeof(cl_status_code), code));
             }

--- a/OpenCLforNet/PlatformLayer/Device.cs
+++ b/OpenCLforNet/PlatformLayer/Device.cs
@@ -20,6 +20,11 @@ namespace OpenCLforNet.PlatformLayer
 
         public Device(Platform platform, int index)
         {
+            if (!platform.Info.IsDeviceInfoObtainable)
+                throw new ArgumentException("This platform has invalid device info.");
+            if (platform.Info.DeviceInfos.Count <= index)
+                throw new IndexOutOfRangeException();
+
             Platform = platform;
             Index = index;
 
@@ -38,7 +43,7 @@ namespace OpenCLforNet.PlatformLayer
                 Marshal.FreeCoTaskMem(new IntPtr(devices));
             }
 
-            Info = Platform.PlatformInfos[platform.Index].DeviceInfos[index];
+            Info = platform.Info.DeviceInfos[index];
         }
 
         public Context CreateContext()

--- a/OpenCLforNet/PlatformLayer/Platform.cs
+++ b/OpenCLforNet/PlatformLayer/Platform.cs
@@ -22,6 +22,14 @@ namespace OpenCLforNet.PlatformLayer
             // create platform infos
             for (int i = 0; i < count; i++)
                 PlatformInfos.Add(new PlatformInfo(i));
+
+            PlatformInfos.Sort((a, b) =>
+            {
+                if (a.IsDeviceInfoObtainable && !b.IsDeviceInfoObtainable) return -1;
+                if (!a.IsDeviceInfoObtainable && b.IsDeviceInfoObtainable) return 1;
+                return 0;
+            });
+
         }
 
         public int Index { get; }

--- a/OpenCLforNet/PlatformLayer/PlatformInfo.cs
+++ b/OpenCLforNet/PlatformLayer/PlatformInfo.cs
@@ -13,6 +13,7 @@ namespace OpenCLforNet.PlatformLayer
 
         public int Index { get; }
         public List<DeviceInfo> DeviceInfos { get; } = new List<DeviceInfo>();
+        public bool IsDeviceInfoObtainable { get; }
 
         private Dictionary<string, byte[]> infos = new Dictionary<string, byte[]>();
 
@@ -49,11 +50,15 @@ namespace OpenCLforNet.PlatformLayer
             }
 
             // get devices
-            OpenCL.clGetDeviceIDs(platform, cl_device_types.CL_DEVICE_TYPE_ALL, 0, null, &count).CheckError();
+            var deviceIdStatus = OpenCL.clGetDeviceIDs(platform, cl_device_types.CL_DEVICE_TYPE_ALL, 0, null, &count);
 
-            // create device infos
-            for (int i = 0; i < count; i++)
-                DeviceInfos.Add(new DeviceInfo(platform, i));
+            IsDeviceInfoObtainable = !deviceIdStatus.HasError();
+            if (IsDeviceInfoObtainable)
+            {
+                // create device infos
+                for (int i = 0; i < count; i++)
+                    DeviceInfos.Add(new DeviceInfo(platform, i));
+            }
         }
 
         public List<string> Keys { get => infos.Keys.ToList(); }


### PR DESCRIPTION
Few days ago, I removed AMD Device and installed nVidia.
I am trying to run the sample and get an exception.

Even if there is no AMD driver on driver-manager, 
clGetPlatformIDs can get it and clGetDeviceIDs seems to get an error.

This PR avoid this problem.

![image](https://user-images.githubusercontent.com/13712028/123663095-08793f80-d871-11eb-8916-450a15e613e3.png)
![image](https://user-images.githubusercontent.com/13712028/123669969-a7a13580-d877-11eb-8f63-cb0650f1e385.png)